### PR TITLE
Format: add 'a' for int16[32] as used in batch IMU logging

### DIFF
--- a/parser.js
+++ b/parser.js
@@ -269,6 +269,13 @@ class DataflashParser {
         for (let i = 0; i < obj.Format.length; i++) {
             temp = obj.Format.charAt(i)
             switch (temp) {
+            case 'a': // int16_t[32]
+                dict[column[i]] = []
+                for (let j = 0; j < 32; j++) {
+                    dict[column[i]][j] = this.data.getInt16(this.offset, true)
+                    this.offset += 2
+                }
+                break
             case 'b':
                 dict[column[i]] = this.data.getInt8(this.offset)
                 this.offset += 1


### PR DESCRIPTION
This adds support for the `a` format as used in https://github.com/ArduPilot/ardupilot/pull/23746

I didn't realise there was such a big diff between the version I used in that and master. I will see it will still work with this version. Ultimately I would like to bring this repo in as a submodule. 