### PR TITLE
rework to allow `get` method to get just a single field.

### DIFF
--- a/parser.js
+++ b/parser.js
@@ -478,9 +478,8 @@ class DataflashParser {
 
     parseAtOffset (name) {
         const msg_FMT = this.getFMT(name)
-        if ((msg_FMT == null) || (msg_FMT.Name == null)) {
-            this.messages[name] = []
-            return []
+        if (msg_FMT == null) {
+            return
         }
 
         const parse = (msg, offsets) => {
@@ -531,12 +530,10 @@ class DataflashParser {
             return parsed
         }
 
-        delete this.messages[name]
-
-        const has_instance = this.messageHasInstances(name)
+        const has_instance = "InstancesOffsetArray" in msg_FMT
         console.log(name, has_instance ? 'has instances' : 'has no instances')
 
-        if (has_instance && ("InstancesOffsetArray" in msg_FMT) && (Object.keys(msg_FMT.InstancesOffsetArray).length > 1)) {
+        if (has_instance) {
             // Parse instances
             for (const [index, offsets] of Object.entries(msg_FMT.InstancesOffsetArray)) {
                 const inst_name = name + '[' + index + ']'
@@ -549,12 +546,7 @@ class DataflashParser {
                 self.postMessage({ percentage: 100 })
             }
 
-
-            // Old behavior was to return the un-fixed and un-split data here
-            // Putting something in this array makes WebTools work but its dumb
-            // Could be anything....
-            this.messages[name] = { found_log: true }
-            return this.messages[name]
+            return
         }
 
         // Parse as single msg
@@ -578,7 +570,6 @@ class DataflashParser {
             self.postMessage({ percentage: 100 })
         }
 
-        return this.messages[name]
     }
 
     checkNumberOfInstances (msg) {

--- a/parser.js
+++ b/parser.js
@@ -857,17 +857,18 @@ class DataflashParser {
                         name: fields[i],
                         units: !msg.units ? '?' : (multipliersTable[msg.multipliers[i]] || '') + msg.units[i],
                         multiplier: !msg.units ? 1.0 : msg.multipliers[i],
-                        Format: msg.Format.charAt(i)
                     }
                 }
                 const availableInstances = this.checkNumberOfInstances(msg)
-                if (availableInstances.length > 1) {
+                if (availableInstances != null) {
+                    messageTypes[msg.Name] = { instances: {} }
                     for (const instance of availableInstances) {
-                        messageTypes[msg.Name + '[' + instance + ']'] = {
+                        const inst_name = msg.Name + '[' + instance + ']'
+                        messageTypes[msg.Name].instances[instance] = inst_name
+                        messageTypes[inst_name] = {
                             expressions: fields,
                             units: msg.units,
                             multipliers: msg.multipliers,
-                            Format: msg.Format,
                             complexFields: complexFields
                         }
                     }
@@ -876,7 +877,6 @@ class DataflashParser {
                         expressions: fields,
                         units: msg.units,
                         multipliers: msg.multipliers,
-                        Format: msg.Format,
                         complexFields: complexFields
                     }
                 }

--- a/parser.js
+++ b/parser.js
@@ -863,17 +863,15 @@ class DataflashParser {
     }
 
     populateUnits () {
-      const FmtTypes = this.messages.FMTU.FmtType
-      const UnitIds = this.messages.FMTU.UnitIds
-      const MultIds = this.messages.FMTU.UnitIds
-      for (const index in FmtTypes) {
-        const type = FmtTypes[index]
+      const FMTU = this.get("FMTU")
+      for (const index in FMTU.FmtType) {
+        const type = FMTU.FmtType[index]
         this.FMT[type].units = []
-        for (const unit of UnitIds[index]) {
+        for (const unit of FMTU.UnitIds[index]) {
             this.FMT[type].units.push(units[unit])
         }
         this.FMT[type].multipliers = []
-        for (const mult of MultIds[index]) {
+        for (const mult of FMTU.MultIds[index]) {
             this.FMT[type].multipliers.push(multipliers[mult])
         }
       }
@@ -919,7 +917,6 @@ class DataflashParser {
         this.data = new DataView(this.buffer)
         this.DfReader()
         const messageTypes = {}
-        this.parseAtOffset('FMTU')
         this.populateUnits()
         for (const msg of this.FMT) {
             if (msg && (msg.Total_Length != 0)) {


### PR DESCRIPTION
This adds a `get` method, it does not store the message, just returns it. It allow getting of single fields. For example `get("POWR", "VServo")` you can also get the a object with all fields `get("POWR")`. This also allows instances with a similar format `get_instance("STAK", inst)` or `get_instance("IMU", inst, "T")`.

There are a two main advantages. If you only need one field its faster and uses less memory. It does not store in the `messages` object, so you don't need to delete it when your done.

This interface does not do the `TimeUS` to `time_boot_ms` conversion and it does not add full names to the mode message. 

This does update the `parseAtOffset` method also, it no longer returns anything and it will now return a instance even if there is only one. 

Finally this swaps over `populateUnits` to use the `get` method so FMTU is not added to the `messages` object.