### PR TITLE
`get_instance` fix instance valid check for instance 0

### DIFF
--- a/parser.js
+++ b/parser.js
@@ -469,7 +469,7 @@ class DataflashParser {
             return
         }
 
-        if (instance && !(("InstancesOffsetArray" in msg_FMT) && (instance in msg_FMT.InstancesOffsetArray))) {
+        if ((instance != null) && !(("InstancesOffsetArray" in msg_FMT) && (instance in msg_FMT.InstancesOffsetArray))) {
             // instance given but no instances or don't have the given instance
             return
         }


### PR DESCRIPTION
Found while debugging https://github.com/ArduPilot/WebTools/pull/222. If instance of 0 bypasses the valid instance checks because it evaluates to false. Need to check not null.  